### PR TITLE
New - Add initiator_name parameter

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,6 +6,7 @@ iscsi::initiator::service::enable:          true
 iscsi::initiator::service::ensure:          running
 iscsi::initiator::service::names:
     - iscsid
+iscsi::initiator::service::initiator_name:  ~
 iscsi::target::package::ensure:             installed
 iscsi::target::package::names:
     - scsi-target-utils

--- a/manifests/initiator/service.pp
+++ b/manifests/initiator/service.pp
@@ -17,6 +17,7 @@ class iscsi::initiator::service (
         Boolean                 $enable,
         Ddolib::Service::Ensure $ensure,
         Array[String[1], 1]     $names,
+        String[1]               $initiator_name,
     ) {
 
     include '::iscsi::initiator::package'


### PR DESCRIPTION
This parameter allows a host to use a custom ISCSI initiator name.
By default this value is set to undef which results in using the
name defined by the iscsi-initiator-utils package.